### PR TITLE
Update transifex client fix #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 .DS_Store
+.transifexrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM alpine
+
+RUN apk add --no-cache bash
+RUN apk --no-cache add curl
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+
 FROM python:2-alpine
 
-RUN set -ex && pip install transifex-client
+COPY --from=0 /tx /bin/tx
+#RUN set -ex && pip install transifex-client

--- a/l10n/tmx.py
+++ b/l10n/tmx.py
@@ -101,12 +101,24 @@ def EnumLanguages():
 def InitializeTransifex(args):
     subprocess.call(['tx', 'init'])
 
+    #subprocess.call(['tx', 'add', 'remote', 
+    #    '--file-filter', 'templates/<lang>/<resource_slug>.<ext>',
+    #    'https://www.transifex.com/apereo/sakai-trunk/dashboard/'])
+
     modules = EnumModules(srcroot)
     l10n.l10n(modules, False, None, False, False)
 
     for module in modules:
-        subprocess.call(['tx', 'set', '--auto-local', '-t', 'PO', '-r', __resource__(module), '<lang>/' +
-                         module + '.po', '--source-lang', 'en', '--source-file', 'templates/' + module + '.pot', '--execute'])
+        print("Adding module '%s'." % module)
+        subprocess.call(['tx', 'add', 
+                            '--organization', 'apereo', 
+                            '--project', project_name,
+                            '--file-filter', '<lang>/' + module + '.po', 
+                            '--type', 'PO', 
+                            '--resource', module,
+                            '--resource-name', module, 
+                            'templates/' + module + '.pot', 
+                            ])
 
 
 # Upload resources to Transifex


### PR DESCRIPTION
This change the current python 2 scripts to use the new transifex client.
This also require a new format in .transifexrc file using a token:
https://developers.transifex.com/docs/cli#migrating-from-older-versions-of-the-client
``` 
[https://www.transifex.com]
rest_hostname = https://rest.api.transifex.com
token         = API_TOKEN_HERE
``` 
The API TOKEN added in Jenkins should be for the SpanishSakai user in transifex.